### PR TITLE
Enable DOCKER_BUILDKIT to skip unnecessary stages

### DIFF
--- a/templates/components/makefile/buildstage-development-body
+++ b/templates/components/makefile/buildstage-development-body
@@ -1,4 +1,4 @@
-	docker build \
+	$(DOCKER_CMD) build \
 		--target development-image \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg WORKDIR=$(WORKDIR) \

--- a/templates/components/makefile/buildstage-production-body
+++ b/templates/components/makefile/buildstage-production-body
@@ -1,4 +1,4 @@
-	docker build \
+	$(DOCKER_CMD) build \
 		--target production-image \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg WORKDIR=$(WORKDIR) \

--- a/templates/components/makefile/file-header
+++ b/templates/components/makefile/file-header
@@ -1,6 +1,7 @@
 IMAGE_NAME := $(shell basename $(CURDIR))
 IMAGE_TAG  := latest
 WORKDIR    := /workspace
+DOCKER_CMD := DOCKER_BUILDKIT=1 docker
 
 .PHONY: development
 development: pre-build build-development-image post-build


### PR DESCRIPTION
Calling `make production` on a project created with the `main` branch:
```
Step 9/20 : FROM base AS development-image
 ---> c840b5321137
Step 10/20 : ARG WORKDIR
 ---> Running in dde3186aeee0
Removing intermediate container dde3186aeee0
 ---> 3bfea5b6f720
Step 11/20 : ENV WORKDIR $WORKDIR
 ---> Running in 2b426a178c7b
Removing intermediate container 2b426a178c7b
 ---> 9e804cebcd1a
Step 12/20 : WORKDIR $WORKDIR
 ---> Running in 23648795137f
Removing intermediate container 23648795137f
 ---> 43c3f6d8f55b
```
We can see the development stage being built.


Calling `make production` on a project created with this PR:
```
[+] Building 1.7s (15/15) FINISHED                                                                                                                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.1s
 => => transferring dockerfile: 1.78kB                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.1s
 => => transferring context: 95B                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                                         0.0s
 => [internal] load build context                                                                                                                                                                                                        0.0s
 => => transferring context: 195B                                                                                                                                                                                                        0.0s
 => [base 1/7] FROM docker.io/library/alpine:latest                                                                                                                                                                                      0.0s
 => CACHED [base 2/7] COPY build/tmp/ /build/                                                                                                                                                                                            0.0s
 => CACHED [base 3/7] COPY build/tmp/packagelist /build/packagelist                                                                                                                                                                      0.0s
 => [base 4/7] RUN if [ -s /build/packagelist ] ; then     apk add $(cat /build/packagelist | sed -r 's/python([2,3]{0,1})-/py\1-/' | xargs) ; fi                                                                                        0.6s
 => [base 5/7] COPY build/tmp/pip /build/pip                                                                                                                                                                                             0.1s
 => [base 6/7] RUN if [ ! -z $(ls /build/pip) ] ; then for path in /build/pip/pip*-req*.txt ;   do $(basename ${path} | cut -d '-' -f 1) install --no-cache-dir -r ${path} ; done ; fi                                                   0.5s
 => [base 7/7] COPY build/resources /build/resources                                                                                                                                                                                     0.0s
 => [pre-production 1/1] COPY workspace /workspace                                                                                                                                                                                       0.1s
 => [production-image 1/2] WORKDIR /workspace                                                                                                                                                                                            0.0s
 => [production-image 2/2] COPY --from=pre-production workspace /workspace                                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                                                   0.1s
 => => exporting layers                                                                                                                                                                                                                  0.1s
 => => writing image sha256:22979180d89334a5dc771f94ad69846735d15eb9eba9e281a65ed42cbd3e485f                                                                                                                                             0.0s
 => => naming to docker.io/library/my-first-docker-bbq-project:latest
```
The development stage is completely skipped.