### PR TITLE
Detect if wget is missing and abort if required

### DIFF
--- a/templates/components/makefile/buildstage-prebuild-body
+++ b/templates/components/makefile/buildstage-prebuild-body
@@ -8,6 +8,6 @@
 		&& if [ ! -z "$$reqs" ] ; then cd build && cp pip*-requirements.txt tmp/pip && for py in $$reqs ; do \
 		printf "$${py}-pip\n$${py}-wheel\n$${py}-setuptools\n" >> tmp/packagelist ; done ; fi
 	# Fetching any remote resources ...
-	@mkdir -p build/resources
-	@if [ -f build/urilist ] ; then cat build/urilist | while read uri ; do echo "Downloading $$uri ..." \
-		&& wget --quiet --no-clobber --directory-prefix build/resources/ $$uri ; done ; fi
+	@mkdir -p build/resources && if [ -f build/urilist ] ; then if [ "$(shell command -v wget)" == "" ] ; then \
+		echo "ERROR: Missing dependency: wget" && exit 1 ; else cat build/urilist | while read uri ; do echo "Downloading \
+		$$uri ..." \ && wget --quiet --no-clobber --directory-prefix build/resources/ $$uri ; done ; fi ; fi


### PR DESCRIPTION
When `wget` is missing from the host and external resources are specified for download the download stage fails but the build continues.

This can be confusing so the modification in this pull-request checks if `wget` is required, then checks if its available, then quits with a warning if it's not available.

`curl` seems to be more available, but `wget` has better support for not re-downloading files if they already exist which is beneficial for saving time during subsequent builds. This behaviour is kind-of supported in `curl` but the server has to support resumable downloads, which not all servers do - so sticking with `wget` is better I think.