### PR TITLE
Revamp repo generation

### DIFF
--- a/bin/create-repo
+++ b/bin/create-repo
@@ -4,6 +4,7 @@ path_base="$(cd "$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")" &
 path_templates="${path_base}/templates"
 path_repositories="${path_templates}/repositories"
 repositories=($(ls "${path_repositories}"))
+default_workspace_name="workspace"
 enable_git=1
 regenerate_repository=0
 
@@ -13,7 +14,7 @@ docker_cmd="DOCKER_BUILDKIT=1 docker"
 usage() {
   cat <<EOF
 Usage: $(basename "${BASH_SOURCE[0]}") <template-name> <project-name>
-       $(basename "${BASH_SOURCE[0]}") --regenerate <template-name>
+       $(basename "${BASH_SOURCE[0]}") --in-place <template-name>
 
   Create a templated docker repository based on the given <template-name>
 
@@ -22,10 +23,10 @@ OPTIONS:
   -h, --help      Print this help and exit
   -l, --list      Print the list of repository templates
   --no-git        To not setup the repository with git
-  --regenerate    Overwrite this repository's Dockerfile & Makefile with the
-                  given <template-name>'s versions. Can be used for changing
-                  an existing repository's base-template, or updating an old
-                  docker-bbq repository to the latest version.
+  --in-place      Create docker repository in the current directory.
+                  Can be used for changing an existing repository's
+                  base-template, or updating an old docker-bbq repository to
+                  the latest version.
 
 EXAMPLES:
 
@@ -70,7 +71,7 @@ case $i in
     --no-git)
     enable_git=0
     ;;
-    --regenerate|-r)
+    --in-place|-i)
     regenerate_repository=1
     ;;
     *) break;
@@ -114,9 +115,9 @@ if [ -z ${dockerfile_args+x} ]; then
 fi
 
 compile_build_args() {
-  vars=(${dockerfile_args[*]})
+  vars=(${dockerfile_args[@]})
   vars+=( "WORKDIR,_" )
-  sorted=($(sort <<<${vars[*]}))
+  sorted=($(printf '%s\n' "${vars[@]}" | IFS="\n" sort))
   for i in ${sorted[*]}; do
     IFS=","; set -- $i; file+=$(printf '''\t\t--build-arg %s=$(%s) ''' "$1" "$1")"\x5C\n";
     unset IFS
@@ -142,17 +143,24 @@ compile_file() {
     fi
     if [[ ${component} == "buildstage-development" ]] \
       || [[ ${component} == "buildstage-production" ]]; then
-      compile_build_args
+      compile_build_args ${dockerfile_args[*]}
     fi
   done
 }
 
 compile_header() {
-  vars=($@)
-  sorted=($(sort <<<${vars[*]}))
+  sorted=($(printf '%s\n' "$@" | sort))
   file=""
   for i in ${sorted[*]}; do
-    IFS=","; set -- $i; file+=$(printf '%-15s := %s\\n' "$1" "$2");
+    IFS=","
+    set -- $i;
+    if [ "$1" == "GROUP_ID" ] && [ "$2" == "_" ]; then
+      file+=$(printf '%-15s ?= %s\\n' "$1" "\$(shell id -u)");
+    elif [ "$1" == "USER_ID" ] && [ "$2" == "_" ]; then
+      file+=$(printf '%-15s ?= %s\\n' "$1" "\$(shell id -g)");
+    else
+      file+=$(printf '%-15s ?= %s\\n' "$1" "$2");
+    fi
     unset IFS
   done
   # Strip the last newline
@@ -164,61 +172,72 @@ if [[ ${regenerate_repository} == 0 ]]; then
   if [ "${enable_git}" == '1' ]; then
     printf "$(cd "${repo_name}" && git init > /dev/null)"
   fi
-  mkdir "${repo_name}"/build
-
-  if [ -z ${workspace_name+x} ]; then
-    mkdir "${repo_name}/workspace"
-  else
-    mkdir "${repo_name}/${workspace_name}"
-  fi
-  mkdir "${repo_name}"/build/resources
-  touch "${repo_name}"/build/packagelist
-
-  file=""
-  compile_file "dockerfile"
-  echo "${file}" | head -c -1 > "${repo_name}/Dockerfile"
-
-  compile_header ${dockerfile_args[*]}
-  compile_file "makefile"
-  printf "${file}" | head -c -1 > "${repo_name}/Makefile"
-
-  file="# ${repo_name}"
-  compile_file "readme"
-  echo "${file}" | head -c -1 > "${repo_name}/README.md"
-
-  # Generate .dockerignore
-  cat ${path_templates}/components/dockerignore  > "${repo_name}"/.dockerignore
-  for component in ${dockerignore_entries[*]}; do
-    echo "${component}" >> "${repo_name}"/.dockerignore
-  done
-
-  # Create any directories and files as listed in the template
-  for directory in ${create_directories[*]}; do
-    mkdir -p "${repo_name}/${directory}"
-  done
-
-  if [ "${enable_git}" == '1' ]; then
-    # Generate .gitignore
-    cat ${path_templates}/components/gitignore  > "${repo_name}"/.gitignore
-    for component in ${gitignore_entries[*]}; do
-      echo "${component}" >> "${repo_name}"/.gitignore
-    done
-
-    # Automatically commit template files
-    printf "$(cd "${repo_name}" && git add . && git commit --quiet --message "Add docker-bbq ${repository} template")"
-  fi
-  echo "Created ${repository} based docker-bbq repo '${repo_name}'"
-else
-  if [ -f Makefile ]; then
-    file=""
-    compile_file "dockerfile"
-    echo "${file}" | head -c -1 > "Dockerfile"
-
-    compile_header ${dockerfile_args[*]}
-    compile_file "makefile"
-    printf "${file}" | head -c -1 > "Makefile"
-    echo "Regenerated docker-bbq repository '$(basename $(pwd))' using template: ${repository}"
-  else
-    echo "Could not find an existing Makefile to regenerate - aborting!"
-  fi
+  cd ${repo_name}
 fi
+
+if [ -z ${workspace_name+x} ]; then
+  workspace_name=${default_workspace_name}
+fi
+
+required_directories=(
+  ${workspace_name}
+  build
+  build/resources
+)
+
+required_files=(
+  build/packagelist
+)
+
+for required_directory in ${required_directories[*]}; do
+  if [ ! -d ${required_directory} ]; then
+    mkdir ${required_directory}
+  fi
+done
+
+for required_file in ${required_files[*]}; do
+  if [ ! -f ${required_file} ]; then
+    touch ${required_file}
+  fi
+done
+
+file=""
+compile_file "dockerfile"
+echo "${file}" | head -c -1 > Dockerfile
+
+dockerfile_args+=(
+  "GROUP_ID,_"
+)
+dockerfile_args+=(
+  "USER_ID,_"
+)
+compile_header ${dockerfile_args[*]}
+compile_file "makefile"
+printf "${file}" | head -c -1 > Makefile
+
+file="# ${repo_name}"
+compile_file "readme"
+echo "${file}" | head -c -1 > README.md
+
+# Generate .dockerignore
+cat ${path_templates}/components/dockerignore  > .dockerignore
+for component in ${dockerignore_entries[*]}; do
+  echo "${component}" >> .dockerignore
+done
+
+# Create any directories and files as listed in the template
+for directory in ${create_directories[*]}; do
+  mkdir -p "${directory}"
+done
+
+if [ "${enable_git}" == '1' ]; then
+  # Generate .gitignore
+  cat ${path_templates}/components/gitignore  > .gitignore
+  for component in ${gitignore_entries[*]}; do
+    echo "${component}" >> .gitignore
+  done
+
+  # Automatically commit template files
+  printf "$(git add . && git commit --quiet --message "Add docker-bbq ${repository} template")"
+fi
+echo "Populated ${repository}-based docker-bbq repository: '${repo_name}'"

--- a/bin/create-repo
+++ b/bin/create-repo
@@ -58,6 +58,8 @@ if [[ $# -eq 0 ]]; then
   usage
 fi
 
+args=()
+
 for i in "$@"
 do
 case $i in
@@ -74,12 +76,14 @@ case $i in
     --in-place|-i)
     regenerate_repository=1
     ;;
-    *) break;
+    *)
+    args+=($1)
+    ;;
   esac
   shift
 done
 
-repository="$1"
+repository="${args[0]}"
 
 check_supported "${repository}"
 
@@ -90,7 +94,7 @@ if [[ ${regenerate_repository} == 0 ]]; then
     exit 1
   fi
 
-  repo_name="$2"
+  repo_name="${args[1]}"
 
   if [[ -d "${repo_name}" ]]; then
     echo "Target directory '${repo_name}' already exists - aborting"

--- a/bin/create-repo
+++ b/bin/create-repo
@@ -106,6 +106,9 @@ if [[ ${regenerate_repository} == 0 ]]; then
     enable_git=0
   fi
 else
+
+  repo_name="$(basename $(pwd))"
+
   # Are we going to be commiting our changes?
   if [ -d .git ] && [ "${enable_git}" == "1" ]; then
     # Is the repository clean?
@@ -241,7 +244,7 @@ for directory in ${create_directories[*]}; do
   mkdir -p "${directory}"
 done
 
-if [ "${repo_name}" != "" ]; then
+if [[ ${regenerate_repository} == 0 ]]; then
   echo "Created ${repository}-based docker-bbq repository: '${repo_name}'"
 else
   echo "Folder has been populated with ${repository}-based docker-bbq template"

--- a/bin/create-repo
+++ b/bin/create-repo
@@ -230,6 +230,7 @@ compile_file "makefile"
 printf "${file}" | head -c -1 > Makefile
 
 file="# ${repo_name}"
+file+=$'\n'
 compile_file "readme"
 echo "${file}" | head -c -1 > README.md
 

--- a/bin/create-repo
+++ b/bin/create-repo
@@ -101,6 +101,16 @@ if [[ ${regenerate_repository} == 0 ]]; then
     echo ${repo_name}" will not be setup with git as ~/.gitconfig could not be found"
     enable_git=0
   fi
+else
+  # Are we going to be commiting our changes?
+  if [ -d .git ] && [ "${enable_git}" == "1" ]; then
+    # Is the repository clean?
+    if [ "$(git status --short)" != "" ]; then
+      echo "ERROR: Current repository is not clean - aborting!"
+      echo "Please commit or stash your current changes and try again."
+      exit 1
+    fi
+  fi
 fi
 
 # Load the components (contains arrays to use eval)

--- a/bin/create-repo
+++ b/bin/create-repo
@@ -261,16 +261,13 @@ if [ "${enable_git}" == '1' ]; then
   if [ -d .git ]; then
     # Were there any changes made?
     if [ "$(git status --short)" != "" ]; then
-      echo "Commiting changes to current git repository"
-      if [[ ${regenerate_repository} == 0 ]]; then
-        commit_message="Add docker-bbq ${repository} template"
+      if [[ ${regenerate_repository} == 1 ]]; then
+        echo "Changes were made to the repository - please check and commit"
       else
-        commit_message="Regenerate docker-bbq ${repository} files"
+        git add . && git commit --quiet --message "Add docker-bbq ${repository} template"
       fi
-      git add . && git commit --quiet --message "${commit_message}"
     else
       echo "Git showed no changes were made to current repository"
     fi
   fi
-
 fi

--- a/bin/create-repo
+++ b/bin/create-repo
@@ -101,10 +101,7 @@ if [[ ${regenerate_repository} == 0 ]]; then
     echo ${repo_name}" will not be setup with git as ~/.gitconfig could not be found"
     enable_git=0
   fi
-else
-  repo_name=""
 fi
-
 
 # Load the components (contains arrays to use eval)
 eval "$(cat "${path_repositories}/${repository}/default.sh")"
@@ -230,6 +227,12 @@ for directory in ${create_directories[*]}; do
   mkdir -p "${directory}"
 done
 
+if [ "${repo_name}" != "" ]; then
+  echo "Created ${repository}-based docker-bbq repository: '${repo_name}'"
+else
+  echo "Folder has been populated with ${repository}-based docker-bbq template"
+fi
+
 if [ "${enable_git}" == '1' ]; then
   # Generate .gitignore
   cat ${path_templates}/components/gitignore  > .gitignore
@@ -237,7 +240,20 @@ if [ "${enable_git}" == '1' ]; then
     echo "${component}" >> .gitignore
   done
 
-  # Automatically commit template files
-  printf "$(git add . && git commit --quiet --message "Add docker-bbq ${repository} template")"
+  # Is this a repository?
+  if [ -d .git ]; then
+    # Were there any changes made?
+    if [ "$(git status --short)" != "" ]; then
+      echo "Commiting changes to current git repository"
+      if [[ ${regenerate_repository} == 0 ]]; then
+        commit_message="Add docker-bbq ${repository} template"
+      else
+        commit_message="Regenerate docker-bbq ${repository} files"
+      fi
+      git add . && git commit --quiet --message "${commit_message}"
+    else
+      echo "Git showed no changes were made to current repository"
+    fi
+  fi
+
 fi
-echo "Populated ${repository}-based docker-bbq repository: '${repo_name}'"

--- a/templates/components/dockerfile/base-create-user-alpine
+++ b/templates/components/dockerfile/base-create-user-alpine
@@ -1,0 +1,10 @@
+
+# Create user account (if necessary)
+ARG GROUP_ID
+ARG USER_ID
+ARG USER_NAME
+RUN if [ "${USER_NAME}" != "root" ]; then \
+  addgroup --gid ${GROUP_ID} ${USER_NAME} \
+  && adduser --disabled-password --gecos '' -G ${USER_NAME} --uid ${USER_ID} ${USER_NAME} ; \
+fi
+USER ${USER_NAME}

--- a/templates/repositories/alpine/default.sh
+++ b/templates/repositories/alpine/default.sh
@@ -11,7 +11,7 @@ dockerfile_components=(
   base-install-apk-packages
   base-install-pip-packages
   base-copy-local-resources
-  base-create-user
+  base-create-user-alpine
   base-setup-workspace-vars
   target-development
   target-development-body

--- a/templates/repositories/alpine/default.sh
+++ b/templates/repositories/alpine/default.sh
@@ -2,8 +2,6 @@
 
 dockerfile_args=(
   BASE_IMAGE,alpine:latest
-  GROUP_ID,1000
-  USER_ID,1000
   USER_NAME,root
   WORKSPACE_NAME,workspace
 )

--- a/templates/repositories/debian/default.sh
+++ b/templates/repositories/debian/default.sh
@@ -3,8 +3,6 @@
 dockerfile_args=(
   APT_MIRROR,auto
   BASE_IMAGE,debian:buster-slim
-  GROUP_ID,1000
-  USER_ID,1000
   USER_NAME,root
   WORKSPACE_NAME,workspace
 )

--- a/templates/repositories/python/default.sh
+++ b/templates/repositories/python/default.sh
@@ -3,8 +3,6 @@
 dockerfile_args=(
   APT_MIRROR,auto
   BASE_IMAGE,python:3-buster
-  GROUP_ID,1000
-  USER_ID,1000
   USER_NAME,root
   WORKSPACE_NAME,workspace
 )

--- a/templates/repositories/ros/default.sh
+++ b/templates/repositories/ros/default.sh
@@ -5,8 +5,6 @@ workspace_name=catkin_ws
 dockerfile_args=(
   APT_MIRROR,auto
   BASE_IMAGE,ros:noetic-ros-base
-  GROUP_ID,1000
-  USER_ID,1000
   USER_NAME,root
   WORKSPACE_NAME,${workspace_name}
 )

--- a/templates/repositories/ros/target-development-body
+++ b/templates/repositories/ros/target-development-body
@@ -1,4 +1,5 @@
 # Add executable to build ROS workspace (cm)
+USER root
 RUN echo "#!/usr/bin/env bash\nset -eu\ncd ${WORKSPACE}\ncatkin_make \
 -j \$(nproc)\nretcode=\$?\nrospack profile\nsource devel/setup.bash\ncd - \
 > /dev/null\nexit \${retcode}" > /usr/bin/cm && chmod +x /usr/bin/cm
@@ -7,3 +8,4 @@ RUN echo "if [[ -f ${WORKSPACE}/devel/setup.bash ]]; then\n\
   source  ${WORKSPACE}/devel/setup.bash\n\
 fi" | tee --append ${HOME}/.bashrc /ros_entrypoint.sh && sed -i '/exec "$@"/d' \
   /ros_entrypoint.sh && echo 'exec "$@"' >> /ros_entrypoint.sh;
+USER $USER_NAME

--- a/templates/repositories/ubuntu/default.sh
+++ b/templates/repositories/ubuntu/default.sh
@@ -5,8 +5,6 @@ tag=${tag:-latest}
 dockerfile_args=(
   APT_MIRROR,auto
   BASE_IMAGE,ubuntu:latest
-  GROUP_ID,1000
-  USER_ID,1000
   USER_NAME,root
   WORKSPACE_NAME,workspace
 )

--- a/tests/definitions/templates.sh
+++ b/tests/definitions/templates.sh
@@ -13,47 +13,78 @@ else
   repositories=(${test_template})
 fi
 
-for repository in ${repositories[*]}; do
-  subheading "${repository} template"
+test_create_repository() {
   name="Create repository"
   pass 'create-repo "${repository}" ${TESTREPO}'
+}
 
+test_build_development_image() {
   cd ${TESTREPO}
   name="Build development image"
   pass 'make'
+}
 
+test_build_production_image() {
   name="Build production image"
   pass 'make production'
+}
 
+test_system_package_installation() {
   name="System package installation"
   printf "tinyproxy\nranger" > build/packagelist
   pass make
+}
 
+test_system_packages_installed() {
   name="System packages installed"
   pass 'run tinyproxy -v | grep "tinyproxy"'
+}
 
+test_packagelist_intact_after_build() {
   name="Packagelist intact after build"
   pass 'cat build/packagelist | grep tinyproxy > /dev/null'
   echo "" > build/packagelist
+}
 
+test_pip_package_installation() {
   printf "pip-date\ntiny" > build/pip3-requirements.txt
   name="PIP package installation"
   pass make
   rm build/pip3-requirements.txt
+}
 
+test_pip_package_installed() {
   name="PIP package installed"
   pass 'run pip-date | grep "Done!"'
+}
 
+test_downloading_external_uris() {
   base_url="https://raw.githubusercontent.com/MarkHedleyJones/docker-bbq/main"
   printf "${base_url}/LICENSE\n${base_url}/README.md\n" > build/urilist
   name="Downloading external URIs"
   pass make
   rm build/urilist
+}
 
+test_downloaded_uri_is_in_image() {
   name="Downloaded URI is in image"
   pass 'run "cat /build/resources/LICENSE | grep "MIT License" && \
             cat /build/resources/README.md | grep "# docker-bbq" && \
             /workspace/target.sh"'
+}
+
+for repository in ${repositories[*]}; do
+  subheading "${repository} template"
+  test_create_repository
+  test_build_development_image
+  test_build_production_image
+  test_system_package_installation
+  test_system_packages_installed
+  test_packagelist_intact_after_build
+  test_pip_package_installation
+  test_pip_package_installed
+  test_downloading_external_uris
+  test_downloaded_uri_is_in_image
 
   # Clean-up
   cd ${base_dir} && rm -rf ${TESTREPO}

--- a/tests/definitions/templates.sh
+++ b/tests/definitions/templates.sh
@@ -73,6 +73,11 @@ test_downloaded_uri_is_in_image() {
             /workspace/target.sh"'
 }
 
+test_build_with_non_root_user_account() {
+  name="Build with non-root user account"
+  pass 'USER_NAME=user make'
+}
+
 for repository in ${repositories[*]}; do
   subheading "${repository} template"
   test_create_repository
@@ -85,6 +90,7 @@ for repository in ${repositories[*]}; do
   test_pip_package_installed
   test_downloading_external_uris
   test_downloaded_uri_is_in_image
+  test_build_with_non_root_user_account
 
   # Clean-up
   cd ${base_dir} && rm -rf ${TESTREPO}


### PR DESCRIPTION
Contains a series of semi-unrelated changes.
1. Improved checking of repository state before overwriting files with `--in-place` option in `create-repo`
2. Allow arguments in Makefile to be overridden
3. Set default user_id and group_id to the current user's values
4. Add tests for user account creation
5. Fix account creation in Alpine based images
6. Fix build of ros based images with non root account

Related #74 