### PR TITLE
Remove DOCKER_BUILDKIT variable

### DIFF
--- a/bin/bbq-create
+++ b/bin/bbq-create
@@ -141,8 +141,11 @@ compile_build_args() {
       elif [ "${i:0:8}" = "USER_NAM" ]; then
         file+='''\t\t--build-arg USER_NAME=$(shell id --user --name) \x5C\n'''
       fi
-    elif [ "${i:0:12}" != "USE_BUILDKIT" ] && [ "${i:0:3}" != "TAG" ]; then
-      IFS=","; set -- $i; file+=$(printf '''\t\t--build-arg %s=$(%s) ''' "$1" "$1")"\x5C\n"; unset IFS
+    elif [ "${i:0:3}" != "TAG" ]; then
+      IFS=","
+      set -- $i
+      file+=$(printf '''\t\t--build-arg %s=$(%s) ''' "$1" "$1")"\x5C\n"
+      unset IFS
     fi
   done
   file+='\t\t--tag $(IMAGE_NAME):'
@@ -182,7 +185,6 @@ compile_header() {
     "USER_GID"
     "USER_NAME"
     "USER_UID"
-    "USE_BUILDKIT"
   )
   for i in ${sorted[*]}; do
     IFS=","
@@ -202,9 +204,6 @@ compile_header() {
     fi
     unset IFS
   done
-  file+=$'\n'
-  file+='# Option to build the image using Docker buildkit\n'
-  file+=$(printf '%-15s ?= %s\\n' "USE_BUILDKIT" "0");
   file=${file%\\n}
 }
 

--- a/templates/components/makefile/buildstage-development
+++ b/templates/components/makefile/buildstage-development
@@ -2,5 +2,5 @@
 # A development build does not include the workspace
 .PHONY: build-development-image
 build-development-image:
-	DOCKER_BUILDKIT=$(USE_BUILDKIT) docker build \
+	docker build \
 		--target development-image \

--- a/templates/components/makefile/buildstage-production
+++ b/templates/components/makefile/buildstage-production
@@ -2,5 +2,5 @@
 # A production build includes the workspace in the final image
 .PHONY: build-production-image
 build-production-image:
-	DOCKER_BUILDKIT=$(USE_BUILDKIT) docker build \
+	docker build \
 		--target production-image \


### PR DESCRIPTION
Removes the DEPRECATED warning by removing DOCKER_BUILDKIT argument