### PR TITLE
Remove pip related tests in alpine

### DIFF
--- a/templates/repositories/alpine/default.sh
+++ b/templates/repositories/alpine/default.sh
@@ -11,7 +11,6 @@ dockerfile_args=(
 dockerfile_components=(
   base-header
   base-install-apk-packages
-  base-install-pip-packages
   base-copy-local-resources
   base-create-user-alpine
   base-setup-workspace-vars

--- a/templates/repositories/alpine/tests.sh
+++ b/templates/repositories/alpine/tests.sh
@@ -3,8 +3,6 @@
 template_tests=(
     build_images.sh
     build_non_root.sh
-    catkin_make.sh
     external_uris.sh
     package_manager.sh
-    pip.sh
 )

--- a/templates/repositories/debian/tests.sh
+++ b/templates/repositories/debian/tests.sh
@@ -3,7 +3,6 @@
 template_tests=(
     build_images.sh
     build_non_root.sh
-    catkin_make.sh
     external_uris.sh
     package_manager.sh
     pip.sh

--- a/templates/repositories/python/tests.sh
+++ b/templates/repositories/python/tests.sh
@@ -3,7 +3,6 @@
 template_tests=(
     build_images.sh
     build_non_root.sh
-    catkin_make.sh
     external_uris.sh
     package_manager.sh
     pip.sh

--- a/templates/repositories/ubuntu/tests.sh
+++ b/templates/repositories/ubuntu/tests.sh
@@ -3,7 +3,6 @@
 template_tests=(
     build_images.sh
     build_non_root.sh
-    catkin_make.sh
     external_uris.sh
     package_manager.sh
     pip.sh

--- a/tests/definitions/templates/README.md
+++ b/tests/definitions/templates/README.md
@@ -1,0 +1,9 @@
+# test definitions
+
+Each test definition is a shell script that is sourced by the main test script.
+The test definition should not exit the shell.
+Each test definition should define define a name variable used to identify the test.
+Each test should use the `pass` alias to run a command that is expected to succeed.
+Each test should use the `fail` alias to run a command that is expected to fail.
+All other variables except `name` should be local.
+Multiple test definitions can be defined in a single file.

--- a/tests/definitions/templates/build_images.sh
+++ b/tests/definitions/templates/build_images.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+name="Build development image"
+pass 'make'
+
+name="Build production image"
+pass 'make production'

--- a/tests/definitions/templates/build_non_root.sh
+++ b/tests/definitions/templates/build_non_root.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+name="Build with non-root user account"
+pass 'USER_NAME=user make'

--- a/tests/definitions/templates/catkin_make.sh
+++ b/tests/definitions/templates/catkin_make.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+name="Catkin build"
+pass 'cd catkin_ws && run catkin_make'

--- a/tests/definitions/templates/external_uris.sh
+++ b/tests/definitions/templates/external_uris.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+name="Downloading external URIs"
+base_url="https://raw.githubusercontent.com/MarkHedleyJones/docker-bbq/main"
+printf "${base_url}/LICENSE\n${base_url}/README.md\n" >build/urilist
+pass make
+rm build/urilist
+
+name="Downloaded URI is in image"
+pass "run 'cat /build/resources/LICENSE | grep \"MIT License\" && \
+        cat /build/resources/README.md | grep \"docker-bbq\" && \
+        /workspace/target.sh'"

--- a/tests/definitions/templates/package_manager.sh
+++ b/tests/definitions/templates/package_manager.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+name="System package installation"
+printf "tinyproxy\nranger" >build/packagelist
+pass make
+
+name="System packages installed"
+pass 'run tinyproxy -v | grep "tinyproxy"'
+
+name="Packagelist intact after build"
+pass 'cat build/packagelist | grep tinyproxy > /dev/null'
+echo "" >build/packagelist

--- a/tests/definitions/templates/pip.sh
+++ b/tests/definitions/templates/pip.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+name="PIP package installation"
+printf "meowsay\ndinosay" >build/pip3-requirements.txt
+pass make
+rm build/pip3-requirements.txt
+
+name="PIP package installed"
+pass 'run dinosay -d trice "Dinosaurs" | grep "Dinosaurs"'


### PR DESCRIPTION
As Alpine no longer allows pip to manage python packages, the ability to install pip packages in the `alpine` template has been removed, along with relevant tests.

This is in response to the following build error
```
#10 1.244     The system-wide python installation should be maintained using the system
#10 1.244     package manager (apk) only.
```